### PR TITLE
bash support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Unit Tests
+      - name: POSIX Shell Unit Tests
         run: |
           docker run \
             --rm \
@@ -24,4 +24,15 @@ jobs:
             -w /mg.sh \
             -u $(id -u):$(id -g) \
             shellspec/shellspec \
+              --format d
+
+      - name: bash Unit Tests
+        run: |
+          docker run \
+            --rm \
+            -v $(pwd):/mg.sh:ro \
+            -w /mg.sh \
+            -u $(id -u):$(id -g) \
+            shellspec/shellspec-debian \
+              --shell=bash \
               --format d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes
 
+## v0.2.0
+
+This release brings proper `bash` awareness and compatibility. I also correct a
+few bugs in the bootstraping code.
+
 ## v0.1.0
 
 This is the first official release of the `mg.sh` library. This release comes as
@@ -22,4 +27,3 @@ of modules is:
 + `portability` provides pure-shell replacements for GNU or Linux specific
   features.
 + `text` provides text-oriented utility functions.
-

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,7 +6,7 @@ __MG_BOOTSTRAP_DEBUG=${__MG_BOOTSTRAP_DEBUG:-0}
 # Declare MG_LIBPATH
 if [ -n "${BASH:-}" ]; then
   # shellcheck disable=SC3028,SC3054 # We know BASH_SOURCE only exists under bash!
-  MG_LIBPATH=${MG_LIBPATH:-$(dirname "${BASH_SOURCE[0]}")}
+  MG_LIBPATH=${MG_LIBPATH:-$( cd -P -- "$(dirname "${BASH_SOURCE[0]}")" && pwd -P )}
   if [ "$__MG_BOOTSTRAP_DEBUG" = "1" ]; then
     printf "Used bash to locate mg.sh at %s\n" "$MG_LIBPATH" >&2
   fi

--- a/controls.sh
+++ b/controls.sh
@@ -120,5 +120,5 @@ backoff_loop() {
 
 # Test variables without eval
 var_exists() { set | grep -q "^${1}="; }
-var_strictly_empty() { set | grep -q "^${1}=''"; }
+var_strictly_empty() { set | grep -qE "^${1}=(''|$)"; }
 var_empty() { ! var_exists "$1" || var_strictly_empty "$1"; }

--- a/locals.sh
+++ b/locals.sh
@@ -5,7 +5,15 @@ __MG_LOCALS_FORCE=${__MG_LOCALS_FORCE:-0}
 
 # This is a cleaned up version of https://stackoverflow.com/a/18600920. It
 # properly passes shellcheck's default set of rules.
-if [ "$__MG_LOCALS_FORCE" = "0" ] && type local | grep -q "shell builtin"; then
+if [ "$__MG_LOCALS_FORCE" = "0" ] && type local 2>/dev/null | grep -q "shell builtin"; then
+  if [ -n "${BASH:-}" ]; then
+    # Remove any exiting aliases
+    alias | sed -E 's/^alias\s+([^=]+)=.*/\1/g' | while IFS= read -r __alias; do
+      unalias "$__alias"
+    done
+    # shellcheck disable=SC3044 # We are running in bash!!
+    shopt -s expand_aliases
+  fi
   alias stack_let=local
   alias stack_unlet=true
 else

--- a/spec/locals_spec.sh
+++ b/spec/locals_spec.sh
@@ -2,11 +2,12 @@
 
 Describe 'locals.sh'
   Include bootstrap.sh
+
   # shellcheck disable=2034 # Internal variable, used mostly for testing
   __MG_LOCALS_FORCE=1; # Force using our implementation to test it
   module locals
 
-  Describe 'let/unlet'
+  Describe 'Internal let/unlet'
     first() {
       stack_let a=first
       echo "$a"

--- a/spec/options_spec.sh
+++ b/spec/options_spec.sh
@@ -8,6 +8,9 @@ Describe 'options.sh'
     trigger() {
       printf %s=%s\\n "$1" "$2"
     }
+    unquote() {
+      sed -E 's/^([A-Z_]+)='\''?([^'\'']*)'\''?$/\1=\2/g'
+    }
     runprefixed() {
       parseopts \
         --prefix "TEST" \
@@ -15,7 +18,8 @@ Describe 'options.sh'
       # Only grep when there is something to grep, otherwise grep would
       # (wrongly) return an error
       if set | grep -q '^TEST_'; then
-        set | sort | grep '^TEST_'
+        # We manually unquote to smooth away differences between shells
+        set | sort | grep '^TEST_' | unquote
       fi
     }
     unprefixed() {
@@ -26,7 +30,8 @@ Describe 'options.sh'
       # Only grep when there is something to grep, otherwise grep would
       # (wrongly) return an error
       if set | grep -q "^${vname}="; then
-        set | sort | grep "^${vname}="
+        # We manually unquote to smooth away differences between shells
+        set | sort | grep "^${vname}=" | unquote
       fi
     }
 
@@ -51,14 +56,14 @@ Describe 'options.sh'
         --options \
           f,flag,theflag FLAG THEFLAG 0 "set flag" \
         -- -f
-      The line 1 should equal "TEST_THEFLAG='1'"
+      The line 1 should equal "TEST_THEFLAG=1"
     End
     It 'Defaults single-dash flag'
       When call runprefixed \
         --options \
           f,flag,theflag FLAG THEFLAG 0 "set flag" \
         --
-      The line 1 should equal "TEST_THEFLAG='0'"
+      The line 1 should equal "TEST_THEFLAG=0"
     End
     It 'Skips defaulting single-dash flag'
       When call runprefixed \
@@ -71,42 +76,42 @@ Describe 'options.sh'
         --options \
           f,flag,theflag FLAG THEFLAG 0 "set flag" \
         -- --flag
-      The line 1 should equal "TEST_THEFLAG='1'"
+      The line 1 should equal "TEST_THEFLAG=1"
     End
     It 'Set supports several double-dashed flag'
       When call runprefixed \
         --options \
           f,flag,theflag FLAG THEFLAG 0 "set flag" \
         -- --theflag
-      The line 1 should equal "TEST_THEFLAG='1'"
+      The line 1 should equal "TEST_THEFLAG=1"
     End
     It 'Set double-dashed flag explicitely (true)'
       When call runprefixed \
         --options \
           f,flag,theflag FLAG THEFLAG 0 "set flag" \
         -- --flag=true
-      The line 1 should equal "TEST_THEFLAG='1'"
+      The line 1 should equal "TEST_THEFLAG=1"
     End
     It 'Set double-dashed flag explicitely (false)'
       When call runprefixed \
         --options \
           f,flag,theflag FLAG THEFLAG 0 "set flag" \
         -- --flag=false
-      The line 1 should equal "TEST_THEFLAG='0'"
+      The line 1 should equal "TEST_THEFLAG=0"
     End
     It 'Set double-dashed flag explicitely (on)'
       When call runprefixed \
         --options \
           f,flag,theflag FLAG THEFLAG 0 "set flag" \
         -- --flag=on
-      The line 1 should equal "TEST_THEFLAG='1'"
+      The line 1 should equal "TEST_THEFLAG=1"
     End
     It 'Fails setting double-dashed flag explicitely with non-boolean value'
       When call runprefixed \
         --options \
           f,flag,theflag FLAG THEFLAG 0 "set flag" \
         -- --flag=hello
-      The line 1 should equal "TEST_THEFLAG='0'"
+      The line 1 should equal "TEST_THEFLAG=0"
       The error should include "boolean"
     End
     It 'Inverts single-dash flag'
@@ -114,21 +119,21 @@ Describe 'options.sh'
         --options \
           f,flag,theflag FLAG,INVERT THEFLAG 0 "set flag" \
         -- -f
-      The line 1 should equal "TEST_THEFLAG='0'"
+      The line 1 should equal "TEST_THEFLAG=0"
     End
     It 'Inverts double-dashed flag'
       When call runprefixed \
         --options \
           f,flag,theflag FLAG,INVERT THEFLAG 0 "set flag" \
         -- --flag
-      The line 1 should equal "TEST_THEFLAG='0'"
+      The line 1 should equal "TEST_THEFLAG=0"
     End
     It 'Inverts double-dashed explicit flag'
       When call runprefixed \
         --options \
           f,flag,theflag FLAG,INVERT THEFLAG 0 "set flag" \
         -- --flag=true
-      The line 1 should equal "TEST_THEFLAG='0'"
+      The line 1 should equal "TEST_THEFLAG=0"
     End
 
     It 'Set single-dash option'
@@ -136,14 +141,14 @@ Describe 'options.sh'
         --options \
           o,option,theoption OPTION THEOPT test "set option" \
         -- -o hello
-      The line 1 should equal "TEST_THEOPT='hello'"
+      The line 1 should equal "TEST_THEOPT=hello"
     End
     It 'Defaults single-dash option'
       When call runprefixed \
         --options \
           o,option,theoption OPTION THEOPT test "set option" \
         --
-      The line 1 should equal "TEST_THEOPT='test'"
+      The line 1 should equal "TEST_THEOPT=test"
     End
     It 'Skips defaulting single-dash option'
       When call runprefixed \
@@ -157,14 +162,14 @@ Describe 'options.sh'
         --options \
           o,option,theoption OPTION THEOPT test "set option" \
         -- --option hello
-      The line 1 should equal "TEST_THEOPT='hello'"
+      The line 1 should equal "TEST_THEOPT=hello"
     End
     It 'Sets several double-dashed options'
       When call runprefixed \
         --options \
           o,option,theoption OPTION THEOPT test "set option" \
         -- --theoption hello
-      The line 1 should equal "TEST_THEOPT='hello'"
+      The line 1 should equal "TEST_THEOPT=hello"
     End
     It 'Overrides several double-dashed options'
       When call runprefixed \
@@ -173,21 +178,21 @@ Describe 'options.sh'
         -- \
           --option nonono \
           --theoption hello
-      The line 1 should equal "TEST_THEOPT='hello'"
+      The line 1 should equal "TEST_THEOPT=hello"
     End
     It 'Sets double-dashed option (modern style with equal sign)'
       When call runprefixed \
         --options \
           o,option,theoption OPTION THEOPT test "set option" \
         -- --option=hello
-      The line 1 should equal "TEST_THEOPT='hello'"
+      The line 1 should equal "TEST_THEOPT=hello"
     End
     It 'Sets empty double-dashed option (modern style with equal sign)'
       When call runprefixed \
         --options \
           o,option,theoption OPTION THEOPT test "set option" \
         -- --option=
-      The line 1 should equal "TEST_THEOPT=''"
+      The line 1 should equal "TEST_THEOPT="
     End
     It 'Triggers with the name of the option'
       When call runprefixed \
@@ -210,7 +215,7 @@ Describe 'options.sh'
         --options \
           f,flag,theflag FLAG THEFLAG 0 "set flag" \
         -- -f
-      The line 1 should equal "THEFLAG='1'"
+      The line 1 should equal "THEFLAG=1"
     End
     It 'Set single-dash option (unprefixed)'
       When call unprefixed \
@@ -218,7 +223,7 @@ Describe 'options.sh'
         --options \
           o,option,theoption OPTION THEOPT test "set option" \
         -- -o hello
-      The line 1 should equal "THEOPT='hello'"
+      The line 1 should equal "THEOPT=hello"
     End
 
     It 'Generates help'
@@ -330,8 +335,8 @@ Describe 'options.sh'
           f,flag,theflag FLAG THEFLAG 0 "set flag" \
           h,help FLAG @HELP - "Print this help" \
         -- --flag --option hello
-      The line 1 should equal "TEST_THEFLAG='1'"
-      The line 2 should equal "TEST_THEOPT='hello'"
+      The line 1 should equal "TEST_THEFLAG=1"
+      The line 2 should equal "TEST_THEOPT=hello"
     End
     It 'Sets flags and options (short)'
       When call runprefixed \
@@ -340,8 +345,8 @@ Describe 'options.sh'
           f,flag,theflag FLAG THEFLAG 0 "set flag" \
           h,help FLAG @HELP - "Print this help" \
         -- -f -o hello
-      The line 1 should equal "TEST_THEFLAG='1'"
-      The line 2 should equal "TEST_THEOPT='hello'"
+      The line 1 should equal "TEST_THEFLAG=1"
+      The line 2 should equal "TEST_THEOPT=hello"
     End
     It 'Sets flags and options (concatenated)'
       When call runprefixed \
@@ -350,8 +355,8 @@ Describe 'options.sh'
           f,flag,theflag FLAG THEFLAG 0 "set flag" \
           h,help FLAG @HELP - "Print this help" \
         -- -fo hello
-      The line 1 should equal "TEST_THEFLAG='1'"
-      The line 2 should equal "TEST_THEOPT='hello'"
+      The line 1 should equal "TEST_THEFLAG=1"
+      The line 2 should equal "TEST_THEOPT=hello"
     End
 
     It 'Reports variables'


### PR DESCRIPTION
This adds bash support to the library. When running within bash, aliasing of `stack_*let` is a bit more difficult as it requires forwarding the aliases to the functions